### PR TITLE
Lowered node-slack-client's cpu allocation to 0

### DIFF
--- a/launch/node-slack-client.yml
+++ b/launch/node-slack-client.yml
@@ -1,11 +1,11 @@
 run:
   type: docker
 env:
-  - AWS_ACCESS_KEY_ID_KUDOBOTDDB
-  - AWS_SECRET_ACCESS_KEY_KUDOBOTDB
-  - JAMILA_ID
-  - KUDOBOT_TOKEN
-  - POTLUCK_ID
+- AWS_ACCESS_KEY_ID_KUDOBOTDDB
+- AWS_SECRET_ACCESS_KEY_KUDOBOTDB
+- JAMILA_ID
+- KUDOBOT_TOKEN
+- POTLUCK_ID
 resources:
-  cpu: 0.1
+  cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
 team: eng-ip


### PR DESCRIPTION
## This an automated PR

*Risk rating*: :moneybag::moneybag::money_with_wings:

Worst case scenario, jobs are a bit slower and fail slightly more often.  The vast majority of our cluster's CPU is unutilized, so it's unlikely the worst case scenario will happen.

## Details:

By their nature, workers are asynchronous, which means most of the time they're not doing much and when they are doing something, it's not super important that they do it quickly.

***But with 0 CPU, how will my worker compute anything?***

Our cluster has CPU for dayz.  Your container will probably run on a machine with an underutilized CPU, which means if your container needs more CPU, it'll get CPU.  That's why it's okay to set a container's CPU to 0.  You can think of the [CPU value](https://github.com/Clever/catapult/blob/65acdd4214a9a878aaf4369670d508cfe940b4dd/launch/catapult.yml#L33) declared in launch yamls as a CPU minimum.  For example, in Catapult's case, it's guaranteed to have access to at least 0.1 CPU cores at all times.

Context:
- https://clever.atlassian.net/browse/INFRA-2120
